### PR TITLE
Sync code with Arduino official analogRead()

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,3 +17,8 @@ framework = arduino
 platform = atmelavr
 board = uno
 framework = arduino
+
+[env:leonardo]
+platform = atmelavr
+board = leonardo
+framework = arduino

--- a/src/analogReadAsync.cpp
+++ b/src/analogReadAsync.cpp
@@ -20,6 +20,7 @@
 #include <avr/interrupt.h>
 #include <util/atomic.h>
 #include <stdint.h>
+#include <Arduino.h>
 
 static volatile analogReadCompleteCallback_t analogReadCompleteCallback = nullptr;
 static const void * volatile analogReadCompleteCallbackData = nullptr;
@@ -36,7 +37,12 @@ bool inFreeRunningMode()
 
 void analogReadAsync(uint8_t pin, analogReadCompleteCallback_t cb, const void *data)
 {
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(analogPinToChannel)
+#if defined(__AVR_ATmega32U4__)
+	if (pin >= 18) pin -= 18; // allow for channel or pin numbers
+#endif
+	pin = analogPinToChannel(pin);
+#elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 	if (pin >= 54) pin -= 54; // allow for channel or pin numbers
 #elif defined(__AVR_ATmega32U4__)
 	if (pin >= 18) pin -= 18; // allow for channel or pin numbers

--- a/src/analogReadAsync.cpp
+++ b/src/analogReadAsync.cpp
@@ -20,7 +20,7 @@
 #include <avr/interrupt.h>
 #include <util/atomic.h>
 #include <stdint.h>
-#include <Arduino.h>
+#include <pins_arduino.h>
 
 static volatile analogReadCompleteCallback_t analogReadCompleteCallback = nullptr;
 static const void * volatile analogReadCompleteCallbackData = nullptr;


### PR DESCRIPTION
This PR synchronizes with the latest code of the official Arduino analogRead() function and fixes bad reads which were happening on Arduino Leonardo.

Thanks for your library, by the way! ;)